### PR TITLE
Preenchendo campos criado_por e atualizado_por

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nsj_rest_lib
-version = 0.0.5
+version = 0.0.6
 author = Nasajon Sistemas
 author_email = contact.dev@nasajon.com.br
 description = Biblioteca para construção de APIs Rest Python, de acordo com o guidelines interno, e com paradigma declarativo.


### PR DESCRIPTION
Preenche os campos "criado_por" e "atualizado_por" quando o modo de acesso for por "access token", mas quando o modo de acesso for "api key" obriga o preenchimento dos mesmos.