### PR TITLE
Correção - grupo empresarial

### DIFF
--- a/src/nsj_rest_lib/controller/get_route.py
+++ b/src/nsj_rest_lib/controller/get_route.py
@@ -73,6 +73,8 @@ class GetRoute(RouteBase):
                     if not ('grupo_empresarial' in self._dto_class.fields_map):
                         raise DTOConfigException(
                             f"Missing 'grupo_empresarial' field declaration on DTOClass: {self._dto_class}")
+                else:
+                    grupo_empresarial = None
 
                 # Construindo os objetos
                 service = self._get_service(factory)


### PR DESCRIPTION
na chamada de grupos-empresariais, caso passasse o parâmetro de grupo_empresarial retornava o erro:
"Erro desconhecido: (pymysql.err.OperationalError) (1054, \"Unknown column 't0.grupo_empresarial' in 'where clause'\")"

Corrigido, caso não seja requerido o grupo empresarial, ele seta None, ignorando caso seja informado o grupo.