### PR TITLE
Permitir string receber uuid

### DIFF
--- a/src/nsj_rest_lib/controller/post_route.py
+++ b/src/nsj_rest_lib/controller/post_route.py
@@ -43,8 +43,7 @@ class PostRoute(RouteBase):
         with self._injector_factory() as factory:
             try:
                 # Recuperando os dados do corpo da rquisição
-                data = request.get_data(as_text=True)
-                data = json_loads(data)
+                data = request.json
 
                 # Convertendo os dados para o DTO
                 data = self._dto_class(**data)

--- a/src/nsj_rest_lib/controller/put_route.py
+++ b/src/nsj_rest_lib/controller/put_route.py
@@ -43,8 +43,7 @@ class PutRoute(RouteBase):
         with self._injector_factory() as factory:
             try:
                 # Recuperando os dados do corpo da rquisição
-                data = request.get_data(as_text=True)
-                data = json_loads(data)
+                data = request.json
 
                 # Convertendo os dados para o DTO
                 data = self._dto_class(**data)

--- a/src/nsj_rest_lib/descriptor/dto_field.py
+++ b/src/nsj_rest_lib/descriptor/dto_field.py
@@ -215,6 +215,12 @@ class DTOField:
         elif self.expected_type is Decimal:
             # Int
             try:
+                value = str(value)
+            except:
+                erro_tipo = True
+        elif self.expected_type is str:
+            # Int
+            try:
                 value = Decimal(value)
             except:
                 erro_tipo = True


### PR DESCRIPTION
Estava usando o json_loads, que transformar string para uuid caso fosse uuid, mas já tinha isso na validação do dtofield, então removi para poder passar um campo como codigo ou uuid.