### PR TITLE
Ajustar filtro de partição no get para permitir nome alternativo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nsj_rest_lib
-version = 0.2.1
+version = 0.2.2
 author = Nasajon Sistemas
 author_email = contact.dev@nasajon.com.br
 description = Biblioteca para construção de APIs Rest Python, de acordo com o guidelines interno, e com paradigma declarativo.

--- a/src/nsj_rest_lib/dao/dao_base.py
+++ b/src/nsj_rest_lib/dao/dao_base.py
@@ -88,7 +88,7 @@ class DAOBase:
         from
             {entity.get_table_name()} as t0
         where
-            t0.{entity.get_pk_column_name()} = :id
+            t0.{entity.get_pk_field()} = :id
             {filters_where}
         """
         values = {"id": id}
@@ -457,7 +457,7 @@ class DAOBase:
         entity = self._entity_class()
 
         # Recuperando o campo de chave primária
-        pk_field = entity.get_pk_column_name()
+        pk_field = entity.get_pk_field()
 
         # Organizando o where dos filtros
         filters_where, filter_values_map = self._make_filters_sql(filters)

--- a/src/nsj_rest_lib/descriptor/dto_field.py
+++ b/src/nsj_rest_lib/descriptor/dto_field.py
@@ -142,14 +142,10 @@ class DTOField:
             '^(\d\d\d\d)-(\d\d)-(\d\d)[T,t](\d\d):(\d\d):(\d\d)$')
         matcher_date = re.compile('^(\d\d\d\d)-(\d\d)-(\d\d)$')
 
-        # Validação por regex
-        if (
-            self.expected_type is datetime.datetime
-            or self.expected_type is datetime.date
-        ) and isinstance(value, str):
-            # Verificando se pode ser alterado de str para UUID
+        # Validação direta de tipos
+        erro_tipo = False
+        if self.expected_type is datetime.datetime and isinstance(value, str):
             match_datetime = matcher_datetime.search(value)
-            match_date = matcher_date.search(value)
 
             if match_datetime:
                 ano = int(match_datetime.group(1))
@@ -161,16 +157,21 @@ class DTOField:
 
                 value = datetime.datetime(
                     year=ano, month=mes, day=dia, hour=hora, minute=minuto, second=segundo)
-            elif match_date:
+            else:
+                erro_tipo=True
+        elif self.expected_type is datetime.date and isinstance(value, str):
+
+            match_date = matcher_date.search(value)
+
+            if match_date:
                 ano = int(match_date.group(1))
                 mes = int(match_date.group(2))
                 dia = int(match_date.group(3))
 
                 value = datetime.date(year=ano, month=mes, day=dia)
-
-        # Validação direta de tipos
-        erro_tipo = False
-        if isinstance(self.expected_type, enum.EnumMeta):
+            else:
+                erro_tipo=True
+        elif isinstance(self.expected_type, enum.EnumMeta):
             # Enumerados
             try:
                 value = self.expected_type(value)
@@ -215,13 +216,13 @@ class DTOField:
         elif self.expected_type is Decimal:
             # Int
             try:
-                value = str(value)
+                value = Decimal(value)
             except:
                 erro_tipo = True
         elif self.expected_type is str:
             # Int
             try:
-                value = Decimal(value)
+                value = str(value)
             except:
                 erro_tipo = True
         else:

--- a/src/nsj_rest_lib/entity/entity_base.py
+++ b/src/nsj_rest_lib/entity/entity_base.py
@@ -14,9 +14,6 @@ class EntityBase(abc.ABC):
         for annotation in self.__annotations__:
             self.__setattr__(annotation, None)  
 
-    def get_pk_column_name(self) -> str:
-        return 'id'
-
     @abc.abstractmethod
     def get_table_name(self) -> str:
         pass

--- a/src/nsj_rest_lib/service/service_base.py
+++ b/src/nsj_rest_lib/service/service_base.py
@@ -553,7 +553,7 @@ class ServiceBase:
 
         # Searching entity in DB
         try:
-            self._dao.get(entity_pk_value, [entity.get_pk_column_name(
+            self._dao.get(entity_pk_value, [entity.get_pk_field(
             )], partition_fields)
         except NotFoundException as e:
             return False

--- a/src/nsj_rest_lib/service/service_base.py
+++ b/src/nsj_rest_lib/service/service_base.py
@@ -49,8 +49,10 @@ class ServiceBase:
         # Handling the fields to retrieve
         entity_fields = self._convert_to_entity_fields(fields['root'])
 
+        entity_filters = self._create_entity_filters(partition_fields)
+
         # Recuperando a entity
-        entity = self._dao.get(id, entity_fields, partition_fields)
+        entity = self._dao.get(id, entity_fields, entity_filters)
 
         # Convertendo para DTO
         dto = self._dto_class(entity)


### PR DESCRIPTION
Ajustar filtro de partição no get para permitir nome alternativo.

Ajustar validação de dados, do tipo str e date principalmente.

Remover método do nome da coluna de pk que era desnecessário.