### PR TITLE
Ponto Web - OP 80081 - Adaptativa - Alteração insert do services par desconsiderar a o uso do profile em caso de não existir as informações de created/updated

### DIFF
--- a/src/nsj_rest_lib/service/service_base.py
+++ b/src/nsj_rest_lib/service/service_base.py
@@ -462,27 +462,28 @@ class ServiceBase:
                         setattr(entity, entity_field, value)
 
             # Setando campos criado_por e atualizado_por quando existirem
-            if hasattr(g, "profile") and g.profile is not None:
-                auth_type_is_api_key = g.profile["authentication_type"] == "api_key"
-                user = g.profile["email"]
-                if insert and hasattr(entity, self._created_by_property):
-                    if not auth_type_is_api_key:
-                        setattr(entity, self._created_by_property, user)
-                    else:
-                        value = getattr(entity, self._created_by_property)
-                        if value is None or value == "":
-                            raise ValueError(
-                                f"É necessário preencher o campo '{self._created_by_property}'."
-                            )
-                if hasattr(entity, self._updated_by_property):
-                    if not auth_type_is_api_key:
-                        setattr(entity, self._updated_by_property, user)
-                    else:
-                        value = getattr(entity, self._updated_by_property)
-                        if value is None or value == "":
-                            raise ValueError(
-                                f"É necessário preencher o campo '{self._updated_by_property}'"
-                            )
+            if (insert and hasattr(entity, self._created_by_property)) or (hasattr(entity, self._updated_by_property)):
+                if hasattr(g, "profile") and g.profile is not None:
+                    auth_type_is_api_key = g.profile["authentication_type"] == "api_key"
+                    user = g.profile["email"]
+                    if insert and hasattr(entity, self._created_by_property):
+                        if not auth_type_is_api_key:
+                            setattr(entity, self._created_by_property, user)
+                        else:
+                            value = getattr(entity, self._created_by_property)
+                            if value is None or value == "":
+                                raise ValueError(
+                                    f"É necessário preencher o campo '{self._created_by_property}'."
+                                )
+                    if hasattr(entity, self._updated_by_property):
+                        if not auth_type_is_api_key:
+                            setattr(entity, self._updated_by_property, user)
+                        else:
+                            value = getattr(entity, self._updated_by_property)
+                            if value is None or value == "":
+                                raise ValueError(
+                                    f"É necessário preencher o campo '{self._updated_by_property}'"
+                                )
 
             # Montando os filtros recebidos (de partição, normalmente)
             if aditional_filters is not None:


### PR DESCRIPTION
Ponto Web - OP 80081 - Adaptativa - Alteração insert do services par desconsiderar a o uso do profile em caso de não existir as informações de created/updated

Identifiquei que quando a biblioteca rest_lib é usado em aplicações não web, a rotina de save do service_base quebra pois não há profile criado. Conforme orientação do Sérgio Silva, incluí uma verificação se o service possui um dos seguintes atributos **_created_by_property**
or 
**_updated_by_property**