### PR TITLE
Melhorando decorator para quando for necessario referenciar o objeto 

### DIFF
--- a/src/nsj_rest_lib/decorator/dto.py
+++ b/src/nsj_rest_lib/decorator/dto.py
@@ -27,7 +27,7 @@ class DTO:
                 "Os parâmetros conjunto_type e conjunto_field devem ser preenchidos juntos (se um for não nulo, ambos devem ser preenchidos)."
             )
 
-    def __call__(self, cls: object):
+    def __call__(self, cls):
         """
         Iterating DTO class to handle DTOFields descriptors.
         """


### PR DESCRIPTION
Fazendo com que o autocomplete referencie os campos do dto corretamente ao instanciar o dto