### PR TITLE
Add ConflictException handling in PutRoute

### DIFF
--- a/src/nsj_rest_lib/controller/put_route.py
+++ b/src/nsj_rest_lib/controller/put_route.py
@@ -9,6 +9,7 @@ from nsj_rest_lib.entity.entity_base import EntityBase
 from nsj_rest_lib.exception import (
     MissingParameterException,
     NotFoundException,
+    ConflictException,
 )
 from nsj_rest_lib.injector_factory_base import NsjInjectorFactoryBase
 from nsj_rest_lib.settings import get_logger
@@ -158,6 +159,12 @@ class PutRoute(RouteBase):
                     return self._handle_exception(e)
                 else:
                     return (format_json_error(e), 400, {**DEFAULT_RESP_HEADERS})
+            except ConflictException as e:
+                get_logger().warning(e)
+                if self._handle_exception is not None:
+                    return self._handle_exception(e)
+                else:
+                    return (format_json_error(e), 409, {**DEFAULT_RESP_HEADERS})
             except NotFoundException as e:
                 get_logger().warning(e)
                 if self._handle_exception is not None:


### PR DESCRIPTION
## Summary
- handle `ConflictException` in `PutRoute`

## Testing
- `make tests` *(fails: ModuleNotFoundError: No module named 'nsj_rest_test_util')*

------
https://chatgpt.com/codex/tasks/task_b_684ae9f057c883338a5bdcd85309f6a2