### PR TITLE
Fix inherited DTO fields

### DIFF
--- a/src/nsj_rest_lib/decorator/dto.py
+++ b/src/nsj_rest_lib/decorator/dto.py
@@ -335,7 +335,18 @@ class DTO:
         """
 
         if attr_name not in cls.__dict__:
-            setattr(cls, attr_name, default_value)
+            inherited = getattr(cls, attr_name, None)
+            if inherited is not None:
+                if isinstance(inherited, dict):
+                    setattr(cls, attr_name, dict(inherited))
+                elif isinstance(inherited, set):
+                    setattr(cls, attr_name, set(inherited))
+                elif isinstance(inherited, list):
+                    setattr(cls, attr_name, list(inherited))
+                else:
+                    setattr(cls, attr_name, inherited)
+            else:
+                setattr(cls, attr_name, default_value)
 
     def set_left_join_fields_map_to_query(
         self,


### PR DESCRIPTION
## Summary
- ensure DTO decorator preserves fields from parent classes

## Testing
- `python -m py_compile src/nsj_rest_lib/decorator/dto.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nsj_rest_test_util')*

------
https://chatgpt.com/codex/tasks/task_b_684af56015e88333ad1d1affa9481d77