### PR TITLE
feat: retornar detalhes estruturados de validação nas rotas de escrita

### DIFF
--- a/src/nsj_rest_lib/controller/patch_route.py
+++ b/src/nsj_rest_lib/controller/patch_route.py
@@ -174,6 +174,14 @@ class PatchRoute(RouteBase):
             if self._handle_exception is not None:
                 return self._handle_exception(e)
             else:
+                details = getattr(e, "details", None)
+                status_code = int(getattr(e, "status_code", 400) or 400)
+                if details is not None:
+                    return (
+                        json_dumps({"error": str(e), "details": details}),
+                        status_code,
+                        {**DEFAULT_RESP_HEADERS},
+                    )
                 return (format_json_error(e), 400, {**DEFAULT_RESP_HEADERS})
         except NotFoundException as e:
             get_logger().warning(e)
@@ -201,3 +209,4 @@ class PatchRoute(RouteBase):
                     500,
                     {**DEFAULT_RESP_HEADERS},
                 )
+

--- a/src/nsj_rest_lib/controller/post_route.py
+++ b/src/nsj_rest_lib/controller/post_route.py
@@ -245,6 +245,14 @@ class PostRoute(RouteBase):
             if self._handle_exception is not None:
                 return self._handle_exception(e)
             else:
+                details = getattr(e, "details", None)
+                status_code = int(getattr(e, "status_code", 400) or 400)
+                if details is not None:
+                    return (
+                        json_dumps({"error": str(e), "details": details}),
+                        status_code,
+                        {**DEFAULT_RESP_HEADERS},
+                    )
                 return (format_json_error(e), 400, {**DEFAULT_RESP_HEADERS})
         except ConflictException as e:
             get_logger().warning(e)
@@ -271,3 +279,4 @@ class PostRoute(RouteBase):
                     500,
                     {**DEFAULT_RESP_HEADERS},
                 )
+

--- a/src/nsj_rest_lib/controller/put_route.py
+++ b/src/nsj_rest_lib/controller/put_route.py
@@ -261,6 +261,14 @@ class PutRoute(RouteBase):
             if self._handle_exception is not None:
                 return self._handle_exception(e)
             else:
+                details = getattr(e, "details", None)
+                status_code = int(getattr(e, "status_code", 400) or 400)
+                if details is not None:
+                    return (
+                        json_dumps({"error": str(e), "details": details}),
+                        status_code,
+                        {**DEFAULT_RESP_HEADERS},
+                    )
                 return (format_json_error(e), 400, {**DEFAULT_RESP_HEADERS})
         except ConflictException as e:
             get_logger().warning(e)
@@ -294,3 +302,4 @@ class PutRoute(RouteBase):
                     500,
                     {**DEFAULT_RESP_HEADERS},
                 )
+


### PR DESCRIPTION
## Contexto
Este PR melhora o retorno de erros de validação nas rotas de escrita.

## Problema
As rotas `POST`, `PUT` e `PATCH` tratavam `BadRequestException` com retorno genérico, dificultando o consumo de detalhes de regras e validações pelo cliente.

## Proposta
Quando a exceção trouxer detalhes estruturados, retornar esses dados no payload de resposta.

## O que foi alterado
- `PostRoute`, `PutRoute` e `PatchRoute` agora:
  - retornam `{ "error": "...", "details": [...] }` quando `details` estiver presente;
  - respeitam `status_code` da exceção quando informado (padrão `400`).
- Mantido o comportamento anterior para exceções sem `details`.

## Impacto
- Melhora observabilidade e tratativa de erro no cliente.
- Mudança retrocompatível para cenários sem payload estruturado.

## Validação
- `python -m compileall` nos arquivos alterados.
